### PR TITLE
More faithful parsing/writing (round-trip)

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -134,8 +134,9 @@ If you wish to override this, you can provide your own routine to generate value
 =item inflate_integer
 
 TOML integers are 64 bit and may not match the size of the compiled perl's
-internal integer type. By default, integers are left as-is as perl strings
-which may be upgraded as needed by the caller.
+internal integer type. By default, integers other than smallish
+decimal integers are left as-is as perl strings which may be upgraded
+as needed by the caller.
 
   my $parser = TOML::Tiny->new(
     inflate_integer => sub{

--- a/README.pod
+++ b/README.pod
@@ -184,6 +184,16 @@ Dates and times which weren't built with DateTime come out as strings.
 Specifying C<inflate_float>, C<inflate_integer>, and
 C<inflate_datetime> is likely to be helpful with this option.
 
+=item datetime_formatter
+
+When encoding a DateTime object, by default C<TOML::Tiny> will use the
+default formatter.  This is not right for TOML which requires RFC3339.
+If you have C<DateTime::Format::RFC3339> available, use this instead:
+
+  my $parser = TOML::Tiny->new(
+    datetime_formatter => DateTime::Format::RFC3339->new(),
+  );
+
 =back
 
 =head2 decode

--- a/README.pod
+++ b/README.pod
@@ -168,6 +168,21 @@ wish to require strictly typed arrays (for C<TOML>'s definition of "type",
 anyway), C<strict_arrays> will produce an error when encountering arrays with
 heterogenous types.
 
+=item no_string_guessing
+
+When encoding a Perl scalar it is not always clear what the TOML type
+of the value is supposed to be.  By default, C<TOML::Tiny> will, for
+unblessed scalars, guess based on the scalar's appearance.  Strings
+that look like numbers, or like datetimes, will be encoded as such.
+
+With no_string_guessing, C<TOML::Tiny> will look at the perl innards
+to find the currently stored value type.  If it is a number, the
+scalar will be encoded as a number.  If it's a string, as a string.
+Dates and times which weren't built with DateTime come out as strings.
+
+Specifying C<inflate_float>, C<inflate_integer>, and
+C<inflate_datetime> is likely to be helpful with this option.
+
 =back
 
 =head2 decode

--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ recommends 'Types::Serialiser' => 0;
 on test => sub{
   requires 'Data::Dumper'              => '0';
   requires 'DateTime::Format::RFC3339' => '0';
+  requires 'DateTime::Format::ISO8601' => '0';
   requires 'Types::Serialiser'         => '0';
   requires 'Math::BigInt'              => '>= 1.999718';
   requires 'TOML::Parser'              => '0';

--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ recommends 'Types::Serialiser' => 0;
 on test => sub{
   requires 'Data::Dumper'              => '0';
   requires 'DateTime::Format::RFC3339' => '0';
+  requires 'Types::Serialiser'         => '0';
   requires 'Math::BigInt'              => '>= 1.999718';
   requires 'TOML::Parser'              => '0';
   requires 'Test2::V0'                 => '0';

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -191,8 +191,9 @@ If you wish to override this, you can provide your own routine to generate value
 =item inflate_integer
 
 TOML integers are 64 bit and may not match the size of the compiled perl's
-internal integer type. By default, integers are left as-is as perl strings
-which may be upgraded as needed by the caller.
+internal integer type. By default, integers other than smallish
+decimal integers are left as-is as perl strings which may be upgraded
+as needed by the caller.
 
   my $parser = TOML::Tiny->new(
     inflate_integer => sub{

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -52,6 +52,7 @@ sub encode {
   my ($self, $data) = @_;
   TOML::Tiny::Writer::to_toml($data,
     strict_arrays => $self->{strict_arrays},
+    datetime_formatter => $self->{datetime_formatter},
     no_string_guessing => $self->{no_string_guessing},
   );
 }
@@ -240,6 +241,16 @@ Dates and times which weren't built with DateTime come out as strings.
 
 Specifying C<inflate_float>, C<inflate_integer>, and
 C<inflate_datetime> is likely to be helpful with this option.
+
+=item datetime_formatter
+
+When encoding a DateTime object, by default C<TOML::Tiny> will use the
+default formatter.  This is not right for TOML which requires RFC3339.
+If you have C<DateTime::Format::RFC3339> available, use this instead:
+
+  my $parser = TOML::Tiny->new(
+    datetime_formatter => DateTime::Format::RFC3339->new(),
+  );
 
 =back
 

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -52,6 +52,7 @@ sub encode {
   my ($self, $data) = @_;
   TOML::Tiny::Writer::to_toml($data,
     strict_arrays => $self->{strict_arrays},
+    no_string_guessing => $self->{no_string_guessing},
   );
 }
 
@@ -223,6 +224,21 @@ By default, C<TOML::Tiny> is flexible and supports heterogenous arrays. If you
 wish to require strictly typed arrays (for C<TOML>'s definition of "type",
 anyway), C<strict_arrays> will produce an error when encountering arrays with
 heterogenous types.
+
+=item no_string_guessing
+
+When encoding a Perl scalar it is not always clear what the TOML type
+of the value is supposed to be.  By default, C<TOML::Tiny> will, for
+unblessed scalars, guess based on the scalar's appearance.  Strings
+that look like numbers, or like datetimes, will be encoded as such.
+
+With no_string_guessing, C<TOML::Tiny> will look at the perl innards
+to find the currently stored value type.  If it is a number, the
+scalar will be encoded as a number.  If it's a string, as a string.
+Dates and times which weren't built with DateTime come out as strings.
+
+Specifying C<inflate_float>, C<inflate_integer>, and
+C<inflate_datetime> is likely to be helpful with this option.
 
 =back
 

--- a/lib/TOML/Tiny/Faithful.pm
+++ b/lib/TOML/Tiny/Faithful.pm
@@ -1,0 +1,82 @@
+
+package TOML::Tiny::Faithful;
+use parent TOML::Tiny;
+use DateTime::Format::RFC3339;
+
+use DateTime;
+use Types::Serialiser; # ensures that Parser DTRT with booleans
+
+our @EXPORT = qw(
+  from_toml
+  to_toml
+);
+
+sub _options {
+  inflate_datetime => sub {
+    DateTime::Format::RFC3339->parse_datetime(shift);
+  },
+  inflate_integer => sub { 
+    use bignum;
+    my $s = shift;
+    $s =~ m/^0o/
+	? Math::BigInt->from_oct($')
+	: Math::BigInt->new($s);
+  },
+  inflate_float => sub { 0. + shift; },
+  no_string_guessing => 1,
+  datetime_formatter => DateTime::Format::RFC3339->new(),
+}
+
+sub new {
+  my ($class, %param) = @_;
+  bless TOML::Tiny->new(_options(), %param), $class;
+}
+sub from_toml {
+  my $source = shift;
+  TOML::Tiny::from_toml($source, _options(), @_);
+}
+sub to_toml {
+  my $source = shift;
+  TOML::Tiny::to_toml($source, _options(), @_);
+}
+
+1;
+
+=head1 SYNOPSIS
+
+  use TOML::Tiny::Faithful qw(from_toml to_toml);
+
+  binmode STDIN,  ':encoding(UTF-8)';
+  binmode STDOUT, ':encoding(UTF-8)';
+
+  # Decoding TOML
+  my $toml = do{ local $/; <STDIN> };
+  my ($parsed, $error) = from_toml $toml;
+
+  # Encoding TOML
+  say to_toml({
+    stuff => {
+      about => ['other', 'stuff'],
+    },
+  });
+
+  # Object API
+  my $parser = TOML::Tiny::Faithful->new;
+  my $data = $parser->decode($toml);
+  say $parser->encode($data);
+
+
+=head1 DESCRIPTION
+
+C<TOML::Tiny::Faithful> is a trivial wrapper around C<TOML::Tiny>
+which sets C<inflate_integer>, C<inflate_float>, C<inflate_datetime>,
+C<no_string_guessing> and C<datetime_formatter> to try to make the
+TOML output faithful to any input TOML.
+
+=head1 SEE ALSO
+
+=over
+
+=item L<TOML::Tiny>
+
+=back

--- a/lib/TOML/Tiny/Faithful.pm
+++ b/lib/TOML/Tiny/Faithful.pm
@@ -1,6 +1,7 @@
 
 package TOML::Tiny::Faithful;
 use parent TOML::Tiny;
+use DateTime::Format::ISO8601;
 use DateTime::Format::RFC3339;
 
 use DateTime;
@@ -13,7 +14,8 @@ our @EXPORT = qw(
 
 sub _options {
   inflate_datetime => sub {
-    DateTime::Format::RFC3339->parse_datetime(shift);
+    # RFC3339 bombs out if there is no timezone, so we parse with 8601
+    DateTime::Format::ISO8601->parse_datetime(shift)
   },
   inflate_integer => sub { 
     use bignum;

--- a/lib/TOML/Tiny/Tokenizer.pm
+++ b/lib/TOML/Tiny/Tokenizer.pm
@@ -178,7 +178,7 @@ sub tokenize_float {
 
 sub tokenize_integer {
   $_[1] =~ tr/_+//d;
-  $_[1];
+  $_[1] !~ m/^0[xob]/ && $_[1] + 0 eq $_[0] ? $_[1] + 0 : "$_[1]"
 }
 
 sub tokenize_string {

--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -110,7 +110,8 @@ sub to_toml {
     }
 
     when (/DateTime/) {
-      return $data->stringify;
+      my $formatter = $param{datetime_formatter};
+      return $formatter ? $formatter->format_datetime($data) : "$data";
     }
 
     when ('Math::BigInt') {

--- a/t/faithful.t
+++ b/t/faithful.t
@@ -28,6 +28,8 @@ boolf=false
 boolt=true
 boolfs="false"
 boolts="true"
+dtlocal=1979-05-27T00:32:00.643144312
+dtlocals="1979-05-27T00:32:00.643144312"
 };
 
 sub norm ($) {

--- a/t/faithful.t
+++ b/t/faithful.t
@@ -1,0 +1,58 @@
+use utf8;
+use Test2::V0;
+use Data::Dumper;
+use DateTime;
+use DateTime::Format::RFC3339;
+use Math::BigInt;
+use Math::BigFloat;
+use TOML::Tiny::Faithful;
+
+binmode STDIN,  ':encoding(UTF-8)';
+binmode STDOUT, ':encoding(UTF-8)';
+
+my $input = q{
+datetime=2020-05-04T16:37:02.905408062+01:00
+datetimes="2020-05-04T16:37:02.905408062+01:00"
+float=3.14
+floats="3.14"
+uint=3
+uints="3"
+nint=-4
+nints="-4"
+bigint=1852528528562625752750
+bigints="1852528528562625752750"
+hex=0x12
+oct=0o751
+bin=0b11010110
+boolf=false
+boolt=true
+boolfs="false"
+boolts="true"
+};
+
+sub norm ($) {
+  join "\n", (
+    sort
+    map {
+      s{=0o(\d+)$}{ '='.oct($1) }e;
+      s{=(0[xb]\w+)$}{ '='.eval($1) }e;
+      $_;
+    }
+    grep /./,
+    split /\n/, $_[0]
+  ), ''
+}
+
+my $parsed = from_toml($input);
+my $actual = norm(to_toml($parsed));
+my $expected = norm($input);
+
+is($actual, $expected, 'round trip') or do{
+  diag 'EXPECTED:';
+  diag Dumper($expected);
+
+  diag 'ACTUAL:';
+  diag Dumper($actual);
+};
+
+done_testing;


### PR DESCRIPTION
Hi.  I have a tool which wants to massage "Cargo.toml" files which are used by the Rust package manager.  I looked at several TOML libraries and yours was the closest to what I needed.  Even so I found that reading and writing a TOML file would make some semantic changes (which broke cargo).  For example, a string that looks like a small integer would, after the round trip, be turned into an integer.

To solve this problem added a few hooks to TOML::Tiny, and added a module on top which uses those hooks and the existing inflate_ parameters to arrange that my TOML files make it through with only the intended changes.

Thanks for your library and I hope you like my contribution.