### PR TITLE
TOML::Tiny: Fix incorrect writing algorithm

### DIFF
--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -16,7 +16,8 @@ my @KEYS;
 sub to_toml {
   my $data = shift;
   my %param = @_;
-  my @buff;
+  my @buff_assign;
+  my @buff_tables;
 
   for (ref $data) {
     when ('HASH') {
@@ -24,7 +25,7 @@ sub to_toml {
       for my $k (grep{ ref($data->{$_}) !~ /HASH|ARRAY/ } sort keys %$data) {
         my $key = to_toml_key($k);
         my $val = to_toml($data->{$k}, %param);
-        push @buff, "$key=$val";
+        push @buff_assign, "$key=$val";
       }
 
       # For values which are arrays, generate inline arrays for non-table
@@ -33,7 +34,7 @@ sub to_toml {
         # Empty table
         if (!@{$data->{$k}}) {
           my $key = to_toml_key($k);
-          push @buff, "$key=[]";
+          push @buff_assign, "$key=[]";
           next ARRAY;
         }
 
@@ -53,7 +54,7 @@ sub to_toml {
         if (@inline) {
           my $key = to_toml_key($k);
           my $val = to_toml(\@inline, %param);
-          push @buff, "$key=$val";
+          push @buff_assign, "$key=$val";
         }
 
         # Table values become an array-of-tables
@@ -61,8 +62,8 @@ sub to_toml {
           push @KEYS, $k;
 
           for (@table_array) {
-            push @buff, '', '[[' . join('.', map{ to_toml_key($_) } @KEYS) . ']]';
-            push @buff, to_toml($_);
+            push @buff_tables, '', '[[' . join('.', map{ to_toml_key($_) } @KEYS) . ']]';
+            push @buff_tables, to_toml($_);
           }
 
           pop @KEYS;
@@ -74,12 +75,12 @@ sub to_toml {
         if (!keys(%{$data->{$k}})) {
           # Empty table
           my $key = to_toml_key($k);
-          push @buff, "$key={}";
+          push @buff_assign, "$key={}";
         } else {
           # Generate [table]
           push @KEYS, $k;
-          push @buff, '', '[' . join('.', map{ to_toml_key($_) } @KEYS) . ']';
-          push @buff, to_toml($data->{$k}, %param);
+          push @buff_tables, '', '[' . join('.', map{ to_toml_key($_) } @KEYS) . ']';
+          push @buff_tables, to_toml($data->{$k}, %param);
           pop @KEYS;
         }
       }
@@ -91,7 +92,7 @@ sub to_toml {
         die "toml: found heterogenous array, but strict_arrays is set ($err)\n" unless $ok;
       }
 
-      push @buff, '[' . join(', ', map{ to_toml($_, %param) } @$data) . ']';
+      push @buff_tables, '[' . join(', ', map{ to_toml($_, %param) } @$data) . ']';
     }
 
     when ('SCALAR') {
@@ -100,7 +101,7 @@ sub to_toml {
       } elsif ($$_ eq '0') {
         return 'false';
       } else {
-        push @buff, to_toml($$_, %param);
+        push @buff_assign, to_toml($$_, %param);
       }
     }
 
@@ -152,7 +153,7 @@ sub to_toml {
     }
   }
 
-  join "\n", @buff;
+  join "\n", @buff_assign, @buff_tables;
 }
 
 sub to_toml_key {


### PR DESCRIPTION
Entries using [ ] and [[ ]] change the default context for assignments.   So we must put all the bare assigments (using `=') (and plain values) first.

See the commit message for a test case.  I have not proivided a new test in-tree since I see you dropped my new test case "t.faithful" from my last MR. If you like, I can resubmit that along with a test for this fix too.

Thanks,
Ian.