### PR TITLE
TOML::Tiny::Writer: Turn DateTime::Format::RFC3339 into a recommends

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,10 +2,10 @@ requires 'perl' => '>= 5.018';
 
 requires 'Carp'                      => '0';
 requires 'Data::Dumper'              => '0';
-requires 'DateTime::Format::RFC3339' => '0';
 requires 'Exporter'                  => '0';
 requires 'Math::BigInt'              => '>= 1.999718';
 
+recommends 'DateTime::Format::RFC3339' => '0';
 recommends 'Types::Serialiser' => 0;
 
 on test => sub{

--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -7,7 +7,6 @@ use v5.18;
 
 use B qw(svref_2object SVf_IOK SVf_NOK);
 use Data::Dumper;
-use DateTime::Format::RFC3339;
 use TOML::Tiny::Grammar;
 use TOML::Tiny::Util qw(is_strict_array);
 
@@ -122,6 +121,8 @@ sub to_toml {
       # to +00:00 for floating time zones. To support local datetimes in
       # output, format the datetime as RFC3339 and strip the timezone
       # when encountering a floating time zone.
+      require DateTime::Format::RFC3339;
+
       my $dt = DateTime::Format::RFC3339->new->format_datetime($data);
 
       if ($data->time_zone_short_name eq 'floating') {


### PR DESCRIPTION
The DateTime::Format::RFC3339 is pretty heavy (at least when it comes to its dependencies), which seems to go counter to the nature of a Tiny module, and it is only needed when encoding TOML, where the caller has created a DateTime object. We can let instead the users that want to use it depend on it directly, and make this module just recommend it and load it only when needed, which seems like an acceptable compromise to reduce the hard dependencies, and would IMO close #8.

I've been unable to run test package test suite though, as dzil was complaining about missing modules, that were not being marked as installed. :(
