### PR TITLE
Mark test dependencies as optional

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+-Mark test dependencies as optional, skipping tests that could not be run (thanks jjatria)
 
 0.13 2021-07-26
 -Fix a spurious warning being raised on trailing spaces in hexadecimal numbers (thanks jjatria)

--- a/build-tests.pl
+++ b/build-tests.pl
@@ -54,6 +54,8 @@ sub deannotate{
             my $src = qq{
               use Test2::Tools::Compare qw(validator);
               validator(sub{
+                use Test2::Require::Module 'DateTime';
+                use Test2::Require::Module 'DateTime::Format::RFC3339';
                 use DateTime;
                 use DateTime::Format::RFC3339;
                 my \$exp = DateTime::Format::RFC3339->parse_datetime("$data->{value}");
@@ -160,12 +162,22 @@ sub build_pospath_test_files{
 
     open my $fh, '>', "$dest/$_.t" or die $!;
 
+    my $optional_deps = '';
+    if ( $data =~ /DateTime/ ) {
+        $optional_deps = <<'DEPS';
+
+use Test2::Require::Module 'DateTime';
+use Test2::Require::Module 'DateTime::Format::RFC3339';
+use DateTime;
+use DateTime::Format::RFC3339;
+DEPS
+        chomp $optional_deps;
+    }
+
     print $fh qq{# File automatically generated from BurntSushi/toml-test
 use utf8;
 use Test2::V0;
-use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
+use Data::Dumper;$optional_deps
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/cpanfile
+++ b/cpanfile
@@ -7,10 +7,12 @@ requires 'Math::BigInt' => '>= 1.999718';
 recommends 'Types::Serialiser' => 0;
 
 on test => sub{
-  requires 'Data::Dumper'              => '0';
-  requires 'DateTime::Format::ISO8601' => '0';
-  requires 'TOML::Parser'              => '0';
-  requires 'Test2::V0'                 => '0';
-  requires 'Test::Pod'                 => '0';
-  requires 'DateTime::Format::RFC3339' => '0';
+  requires 'Data::Dumper' => '0';
+  requires 'Test2::V0'    => '0';
+  requires 'Test::Pod'    => '0';
+
+  recommends 'DateTime'                  => '0';
+  recommends 'DateTime::Format::RFC3339' => '0';
+  recommends 'DateTime::Format::ISO8601' => '0';
+  recommends 'TOML::Parser'              => '0';
 };

--- a/t/parity.t
+++ b/t/parity.t
@@ -7,6 +7,7 @@
 use Test2::V0;
 use Data::Dumper;
 use TOML::Tiny::Parser;
+use Test2::Require::Module 'TOML::Parser';
 
 my $toml = do{ local $/; <DATA> };
 
@@ -29,6 +30,7 @@ subtest 'TOML::Parser' => sub{
   };
 
   subtest 'inflate_datetime' => sub{
+    Test2::Require::Module->import('DateTime::Format::RFC3339');
     require DateTime::Format::RFC3339;
     my $inflate = sub{ DateTime::Format::RFC3339->parse_datetime(shift) };
     my $exp = TOML::Parser->new(inflate_datetime => $inflate)->parse($toml);

--- a/t/toml-test/valid/array-empty.t
+++ b/t/toml-test/valid/array-empty.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/array-nospaces.t
+++ b/t/toml-test/valid/array-nospaces.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/array-string-quote-comma-2.t
+++ b/t/toml-test/valid/array-string-quote-comma-2.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/array-string-quote-comma.t
+++ b/t/toml-test/valid/array-string-quote-comma.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/array-string-with-comma.t
+++ b/t/toml-test/valid/array-string-with-comma.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/array-table-array-string-backslash.t
+++ b/t/toml-test/valid/array-table-array-string-backslash.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/arrays-hetergeneous.t
+++ b/t/toml-test/valid/arrays-hetergeneous.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/arrays-nested.t
+++ b/t/toml-test/valid/arrays-nested.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/arrays.t
+++ b/t/toml-test/valid/arrays.t
@@ -2,6 +2,8 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
+use Test2::Require::Module 'DateTime';
+use Test2::Require::Module 'DateTime::Format::RFC3339';
 use DateTime;
 use DateTime::Format::RFC3339;
 use Math::BigInt;

--- a/t/toml-test/valid/bool.t
+++ b/t/toml-test/valid/bool.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/comments-at-eof.t
+++ b/t/toml-test/valid/comments-at-eof.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/comments-at-eof2.t
+++ b/t/toml-test/valid/comments-at-eof2.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/comments-everywhere.t
+++ b/t/toml-test/valid/comments-everywhere.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/datetime-timezone.t
+++ b/t/toml-test/valid/datetime-timezone.t
@@ -2,6 +2,8 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
+use Test2::Require::Module 'DateTime';
+use Test2::Require::Module 'DateTime::Format::RFC3339';
 use DateTime;
 use DateTime::Format::RFC3339;
 use Math::BigInt;

--- a/t/toml-test/valid/datetime.t
+++ b/t/toml-test/valid/datetime.t
@@ -2,6 +2,8 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
+use Test2::Require::Module 'DateTime';
+use Test2::Require::Module 'DateTime::Format::RFC3339';
 use DateTime;
 use DateTime::Format::RFC3339;
 use Math::BigInt;

--- a/t/toml-test/valid/double-quote-escape.t
+++ b/t/toml-test/valid/double-quote-escape.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/empty.t
+++ b/t/toml-test/valid/empty.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/escaped-escape.t
+++ b/t/toml-test/valid/escaped-escape.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/example.t
+++ b/t/toml-test/valid/example.t
@@ -2,6 +2,8 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
+use Test2::Require::Module 'DateTime';
+use Test2::Require::Module 'DateTime::Format::RFC3339';
 use DateTime;
 use DateTime::Format::RFC3339;
 use Math::BigInt;

--- a/t/toml-test/valid/exponent-part-float.t
+++ b/t/toml-test/valid/exponent-part-float.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/float-exponent.t
+++ b/t/toml-test/valid/float-exponent.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/float-underscore.t
+++ b/t/toml-test/valid/float-underscore.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/float.t
+++ b/t/toml-test/valid/float.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/implicit-and-explicit-after.t
+++ b/t/toml-test/valid/implicit-and-explicit-after.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/implicit-and-explicit-before.t
+++ b/t/toml-test/valid/implicit-and-explicit-before.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/implicit-groups.t
+++ b/t/toml-test/valid/implicit-groups.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/inline-table-array.t
+++ b/t/toml-test/valid/inline-table-array.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/inline-table.t
+++ b/t/toml-test/valid/inline-table.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/integer-underscore.t
+++ b/t/toml-test/valid/integer-underscore.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/integer.t
+++ b/t/toml-test/valid/integer.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/key-equals-nospace.t
+++ b/t/toml-test/valid/key-equals-nospace.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/key-numeric.t
+++ b/t/toml-test/valid/key-numeric.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/key-space.t
+++ b/t/toml-test/valid/key-space.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/key-special-chars.t
+++ b/t/toml-test/valid/key-special-chars.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/keys-with-dots.t
+++ b/t/toml-test/valid/keys-with-dots.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/long-float.t
+++ b/t/toml-test/valid/long-float.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/long-integer.t
+++ b/t/toml-test/valid/long-integer.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/multiline-string.t
+++ b/t/toml-test/valid/multiline-string.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/nested-inline-table-array.t
+++ b/t/toml-test/valid/nested-inline-table-array.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/newline-crlf.t
+++ b/t/toml-test/valid/newline-crlf.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/newline-lf.t
+++ b/t/toml-test/valid/newline-lf.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/raw-multiline-string.t
+++ b/t/toml-test/valid/raw-multiline-string.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/raw-string.t
+++ b/t/toml-test/valid/raw-string.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/right-curly-brace-after-boolean.t
+++ b/t/toml-test/valid/right-curly-brace-after-boolean.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/string-empty.t
+++ b/t/toml-test/valid/string-empty.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/string-escapes.t
+++ b/t/toml-test/valid/string-escapes.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/string-nl.t
+++ b/t/toml-test/valid/string-nl.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/string-simple.t
+++ b/t/toml-test/valid/string-simple.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/string-with-pound.t
+++ b/t/toml-test/valid/string-with-pound.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-array-implicit.t
+++ b/t/toml-test/valid/table-array-implicit.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-array-many.t
+++ b/t/toml-test/valid/table-array-many.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-array-nest.t
+++ b/t/toml-test/valid/table-array-nest.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-array-one.t
+++ b/t/toml-test/valid/table-array-one.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-array-table-array.t
+++ b/t/toml-test/valid/table-array-table-array.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-empty.t
+++ b/t/toml-test/valid/table-empty.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-no-eol.t
+++ b/t/toml-test/valid/table-no-eol.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-sub-empty.t
+++ b/t/toml-test/valid/table-sub-empty.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-whitespace.t
+++ b/t/toml-test/valid/table-whitespace.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-with-literal-string.t
+++ b/t/toml-test/valid/table-with-literal-string.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-with-pound.t
+++ b/t/toml-test/valid/table-with-pound.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/table-with-single-quotes.t
+++ b/t/toml-test/valid/table-with-single-quotes.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/underscored-float.t
+++ b/t/toml-test/valid/underscored-float.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/underscored-integer.t
+++ b/t/toml-test/valid/underscored-integer.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/unicode-escape.t
+++ b/t/toml-test/valid/unicode-escape.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/toml-test/valid/unicode-literal.t
+++ b/t/toml-test/valid/unicode-literal.t
@@ -2,8 +2,6 @@
 use utf8;
 use Test2::V0;
 use Data::Dumper;
-use DateTime;
-use DateTime::Format::RFC3339;
 use Math::BigInt;
 use Math::BigFloat;
 use TOML::Tiny;

--- a/t/writer.t
+++ b/t/writer.t
@@ -3,8 +3,7 @@ use warnings;
 
 use Test2::V0;
 use TOML::Tiny;
-use DateTime::Format::RFC3339;
-use DateTime::Format::ISO8601;
+require Test2::Require::Module;
 
 my $src = do{ local $/; <DATA> };
 
@@ -36,6 +35,9 @@ subtest strict_arrays => sub{
 # Adapted from DateTime::Format::RFC3339.
 #-------------------------------------------------------------------------------
 subtest 'rfc3339 datetimes' => sub{
+  Test2::Require::Module->import('DateTime');
+  require DateTime;
+
   my $dt;
 
   $dt = DateTime->new(year => 2002, month => 7, day => 1, hour => 13, minute => 50, second => 5, time_zone => 'UTC');


### PR DESCRIPTION
Although TOML::Tiny no longer depends on DateTime::Format::RFC3339, a default install of TOML::Tiny still brings in this module only to run a parity test.

This PR marks that dependency as recommended for the test suite, and skips those tests when the module is not available.

In the spirit of keeping this as close as possible to a ::Tiny distribution, the same is done for DateTime and TOML::Parser, which makes the test suite pass even without those non-core dependencies.

Test::Pod and Test2::Suite remain as non-core dependencies, but at least the latter cannot really be helped.