### PR TITLE
Spaces are not hexadecimal digits

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+-Fix a spurious warning being raised on trailing spaces in hexadecimal numbers (thanks jjatria)
 
 0.12 2021-05-28
 -Fix bug causing to_toml to incorrectly dereference \1 and \0 (thanks oschwald)

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -421,4 +421,6 @@ A big thank you to those who have contributed code or bug reports:
 
 =item L<oschwald|https://github.com/oschwald>
 
+=item L<jjatria|https://metacpan.org/author/JJATRIA>
+
 =back

--- a/lib/TOML/Tiny/Grammar.pm
+++ b/lib/TOML/Tiny/Grammar.pm
@@ -108,7 +108,7 @@ our $DateTime = qr/(?> $Date (?> [T ] $Time )?) | $Time/x;
 #-----------------------------------------------------------------------------
 our $DecFirstChar = qr/[1-9]/;
 our $DecChar      = qr/[0-9]/;
-our $HexChar      = qr/[0-9 a-f A-F]/;
+our $HexChar      = qr/[0-9a-fA-F]/;
 our $OctChar      = qr/[0-7]/;
 our $BinChar      = qr/[01]/;
 

--- a/t/numbers.t
+++ b/t/numbers.t
@@ -35,6 +35,7 @@ subtest 'integers' => sub{
     is from_toml('x=0xdeadbeef'), {x => 0xDEADBEEF}, 'all lower';
     is from_toml('x=0xDeAdBeEf'), {x => 0xDEADBEEF}, 'mixed caps';
     is from_toml('x=0xDEAD_BEEF'), {x => 0xDEADBEEF}, 'underscores';
+    is from_toml('x=0xDEADBEEF '), {x => 0xDEADBEEF}, 'trailing space';
 
     is from_toml('x=0x7fffffffffffffff'), hash{
       field x => validator(sub{


### PR DESCRIPTION
The spaces in the character class for the `$HexChar` rule in TOML::Tiny::Grammar were not escaped, which meant that a space was also taken to be a part of the number. This meant that parsing any hex number with trailing spaces raised a warning like the following:

    Illegal hexadecimal digit ' ' ignored at .../TOML/Tiny/Parser.pm line 383.

Having trailing spaces might seem like something that we should not strive to support, but they are not uncommon to have in otherwise valid TOML:

    white = [ 0xff, 0xff, 0xff ]

This patch sacrifices some readability in the character class by removing the spaces, but means that TOML can be parsed with no warnings.

There are a couple of alternative ways to solve this: `/xx` could have been added to keep the spaces, but that requires us to bump the minimum Perl to 5.26. Another alternative is to use `[[:xdigit:]]` as the character class, but I'm not sure what the minimum Perl would be in that case, and it seemed to go against the style of the rest of the grammar.
