### PR TITLE
Roundtrip Nan, Inf, and -Inf

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+- Fix an issue with serialisation of nan, inf, and -inf (thanks jjatria)
 
 0.13 2021-07-26
 -Fix a spurious warning being raised on trailing spaces in hexadecimal numbers (thanks jjatria)

--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -130,6 +130,9 @@ sub to_toml {
       # note: this must come before any regex can flip this flag off
       return $data if svref_2object(\$data)->FLAGS & (SVf_IOK | SVf_NOK);
       return $data if $data =~ /$DateTime/;
+      return 'inf' if $data == 'inf';
+      return '-inf' if $data == -'inf';
+      return 'nan' if $data != $data;
       return to_toml_string($data);
     }
 

--- a/t/numbers.t
+++ b/t/numbers.t
@@ -121,6 +121,9 @@ subtest 'floats' => sub{
 subtest 'round trip preserves numerical values' => sub{
   is to_toml(from_toml('port=1234')), 'port=1234', 'integers';
   is to_toml(from_toml('pi=3.14')), 'pi=3.14', 'floats';
+  is to_toml(from_toml('nan=nan')), 'nan=nan', 'nan';
+  is to_toml(from_toml('pos=inf')), 'pos=inf', 'inf';
+  is to_toml(from_toml('neg=-inf')), 'neg=-inf', '-inf';
 };
 
 done_testing;


### PR DESCRIPTION
I came across this while investigating some of the failures in #14. I'd be happy to move this implementation around if it's not in the right place, but this seems to cover the common cases  at least.

The `nan` check was lifted from [Data::Float](https://metacpan.org/dist/Data-Float/source/lib/Data/Float.pm#L688).