### PR TITLE
Replace @Author::BLUEFEET with equivalent config

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,5 +3,31 @@ author = Jeff Ober <sysread@fastmail.fm>
 license = Perl_5
 copyright_holder = Jeff Ober
 
-[@Author::BLUEFEET]
+[@Basic]
+
+[Git::Check]
+
+[Git::NextVersion]
+first_version = 0.01
+
+[NextRelease]
+format = %v %{yyyy-MM-dd}d
+
+[ReadmeAnyFromPod / ReadmePodInRoot]
+type = pod
+
+[GithubMeta]
+issues = 1
+
+[PkgVersion]
+[PodSyntaxTests]
+[Test::ReportPrereqs]
+[Prereqs::FromCPANfile]
+
+[MetaJSON]
+
+[Git::Commit]
+[Git::Tag]
+[Git::Push]
+
 [PodWeaver]


### PR DESCRIPTION
Dist::Zilla::PluginBundle::Author::BLUEFEET has been deleted from CPAN,
so let's replace that bundle with the equivalent long form
configuration. This was copied from
https://metacpan.org/release/BLUEFEET/Dist-Zilla-PluginBundle-Author-BLUEFEET-0.03/view/lib/Dist/Zilla/PluginBundle/Author/BLUEFEET.pm
but I also did a visual check to ensure that the docs match the
internals of that plugin bundle.
