### PR TITLE
inline table keys were not normalized via to_toml_key()

### DIFF
--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -90,13 +90,14 @@ sub to_toml_inline_table {
   my ($data, $param) = @_;
   my @buff;
 
-  for my $key (keys %$data) {
-    my $value = $data->{$key};
+  for my $k (keys %$data) {
+    my $key = to_toml_key($k);
+    my $val = $data->{$k};
 
-    if (ref $value eq 'HASH') {
-      push @buff, $key . '=' . to_toml_inline_table($value);
+    if (ref $val eq 'HASH') {
+      push @buff, $key . '=' . to_toml_inline_table($val);
     } else {
-      push @buff, $key . '=' . to_toml($value);
+      push @buff, $key . '=' . to_toml($val);
     }
   }
 

--- a/t/writer.t
+++ b/t/writer.t
@@ -72,6 +72,23 @@ subtest 'oddballs and regressions' => sub{
       like $@, qr/found undefined value/;
 
   };
+
+  subtest 'quoted inline table keys' => sub {
+
+      my $data = { q{foo} => [ q{bar}, { q{<=} => 33 } ] } ;
+      my $encoded = to_toml( $data );
+
+      my $decoded;
+      ok( lives { $decoded = from_toml( $encoded ) },
+          'decode succeeded' ) or note $@;
+
+      SKIP: {
+            skip 'error in encoding' unless $decoded;
+            is ( $decoded, $data, 'round trip successful' )
+        }
+
+  };
+
 };
 
 subtest 'to_toml_array' => sub{

--- a/t/writer.t
+++ b/t/writer.t
@@ -81,12 +81,7 @@ subtest 'oddballs and regressions' => sub{
       my $decoded;
       ok( lives { $decoded = from_toml( $encoded ) },
           'decode succeeded' ) or note $@;
-
-      SKIP: {
-            skip 'error in encoding' unless $decoded;
-            is ( $decoded, $data, 'round trip successful' )
-        }
-
+      is ( $decoded, $data, 'round trip successful' );
   };
 
 };


### PR DESCRIPTION
to_toml_key() ensures that keys are properly quoted if they contain characters outside of the set which may appear in unquoted keys.

also, rename variables for key an value to match the standard in the rest of the code.

QUESTION:  Where should I put the test?