### PR TITLE
Add a test case for quoted keys, which currently fails

### DIFF
--- a/t/writer.t
+++ b/t/writer.t
@@ -132,6 +132,15 @@ hosts = [
   "omega"
 ]
 
+[cfg."something with a 'single-quote'".nested]
+inner = "forty-one"
+
+[cfg.'something with a "double-quote"'.nested]
+inner = "forty-two"
+
+[cfg."something with a 'single-quote' and a \"double-quote\"".nested]
+inner = "forty-three"
+
 [[products]]
 name = "Hammer"
 sku = 738594937


### PR DESCRIPTION
This adds a test case that I have carried downstream for a while but which never made it upstream.  Unfortunately the test fails with current master.