### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
First-time Dependabot setup for this repo.

This is a Perl/Dist::Zilla distribution, and Dependabot has no native CPAN ecosystem support, so the only applicable ecosystem is **`github-actions`** (the CI workflow `dzil-test.yml` uses `actions/checkout@v3`).

## Changes
- Add `.github/dependabot.yml` with a `github-actions` entry (weekly schedule)
- **`major-updates` group** — batches major action bumps together so coordinated releases (e.g. upload/download-artifact) stay atomic
- **`minor-and-patch` group** — rolls routine minor + patch bumps into a single PR to cut noise
- **7-day cooldown** — waits a week after a release before opening a PR, so broken releases get yanked or patched first

## Testing
- Validated the file parses: `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)