### PR TITLE
workflow: use perl-actions/setup-cpm for module installation

### DIFF
--- a/.github/workflows/dzil-test.yml
+++ b/.github/workflows/dzil-test.yml
@@ -46,6 +46,11 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: perl -V
         run: perl -V
+      - name: Set up cpm
+        uses: perl-actions/setup-cpm@v1
+        with:
+          # 'compat' installs cpm 0.998003 on older Perls and the latest cpm on newer ones.
+          version: compat
       - name: Install Dependencies
         run: cpm install -g --no-test --show-build-log-on-failure --cpanfile cpanfile
       - name: Run tests


### PR DESCRIPTION
Add a `setup-cpm@v1` step (`version: compat`) before running `cpm install`, so older Perls in the matrix get a compatible cpm release.

This change was extracted from commit d295fcd on the `fix-46` branch into its own PR, branched fresh from `origin/master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)