### PR TITLE
Limit maximum nesting depth to prevent resource exhaustion

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Limit maximum nesting depth of inline arrays and tables (default 128,
+  configurable via max_depth) to prevent resource exhaustion on
+  pathologically nested input (Olaf Alders, Claude)
+
 0.22 2026-06-03
 
 - Fix tests when Types::Serialiser is absent (GH#46) (Olaf Alders, Claude)

--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 {{$NEXT}}
 
-- Limit maximum nesting depth of inline arrays and tables (default 128,
-  configurable via max_depth) to prevent resource exhaustion on
-  pathologically nested input (Olaf Alders, Claude)
+- Limit maximum nesting depth of inline arrays, inline tables, and dotted
+  keys (default 128, configurable via max_depth) to prevent resource
+  exhaustion on pathologically nested input (Olaf Alders, Claude)
 
 0.22 2026-06-03
 

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -346,6 +346,15 @@ B<Note:> C<strict> was previously called C<strict_arrays>. Both are accepted
 for backward compatibility, although enforcement of homogenous arrays is no
 longer supported as it has been dropped from the spec.
 
+=item max_depth
+
+Limits how deeply inline arrays and inline tables may nest. Input that nests
+beyond this limit results in a parse error rather than unbounded recursion and
+memory growth. The default is C<128>, which is far beyond what real documents
+require. Pass a larger value to permit deeper nesting:
+
+  my $parser = TOML::Tiny->new( max_depth => 512 );
+
 =back
 
 

--- a/lib/TOML/Tiny.pm
+++ b/lib/TOML/Tiny.pm
@@ -348,10 +348,10 @@ longer supported as it has been dropped from the spec.
 
 =item max_depth
 
-Limits how deeply inline arrays and inline tables may nest. Input that nests
-beyond this limit results in a parse error rather than unbounded recursion and
-memory growth. The default is C<128>, which is far beyond what real documents
-require. Pass a larger value to permit deeper nesting:
+Limits how deeply inline arrays, inline tables, and dotted keys may nest. Input
+that nests beyond this limit results in a parse error rather than unbounded
+recursion and memory growth. The default is C<128>, which is far beyond what
+real documents require. Pass a larger value to permit deeper nesting:
 
   my $parser = TOML::Tiny->new( max_depth => 512 );
 

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -32,6 +32,12 @@ sub new {
     inflate_datetime => $param{inflate_datetime} || sub{ shift },
     inflate_boolean  => $param{inflate_boolean}  || sub{ shift eq 'true' ? $TRUE : $FALSE },
     strict           => $param{strict},
+
+    # Upper bound on inline array/table nesting, guarding against resource
+    # exhaustion from pathologically nested input (a small document can
+    # otherwise drive unbounded recursion, memory growth, and CPU). 128 is far
+    # beyond what real documents require and matches other TOML implementations.
+    max_depth        => defined $param{max_depth} ? $param{max_depth} : 128,
   }, $class;
 }
 
@@ -49,6 +55,7 @@ sub parse {
   }
 
   $self->{tokenizer}    = TOML::Tiny::Tokenizer->new(source => $toml);
+  $self->{depth}        = 0;
   $self->{keys}         = [];
   $self->{root}         = {};
   $self->{tables}       = {}; # "seen" hash of explicitly defined table names (e.g. [foo])
@@ -59,6 +66,7 @@ sub parse {
   my $result = $self->{root};
 
   delete $self->{tokenizer};
+  delete $self->{depth};
   delete $self->{keys};
   delete $self->{root};
   delete $self->{tables};
@@ -104,6 +112,13 @@ sub expect_type {
     unless $actual =~ /$expected/;
 }
 
+
+sub check_depth {
+  my ($self, $token) = @_;
+  if ($self->{depth} > $self->{max_depth}) {
+    $self->parse_error($token, "exceeded maximum nesting depth of $self->{max_depth}");
+  }
+}
 
 sub current_key {
   my $self = shift;
@@ -322,8 +337,17 @@ sub parse_value {
   return $self->inflate_integer($token) if $type eq 'integer';
   return $self->{inflate_boolean}->($token->{value}) if $type eq 'bool';
   return $self->parse_datetime($token) if $type eq 'datetime';
-  return $self->parse_inline_table($token) if $type eq 'inline_table';
-  return $self->parse_array($token) if $type eq 'inline_array';
+
+  if ($type eq 'inline_table' || $type eq 'inline_array') {
+    # parse_value, parse_array, and parse_inline_table form a mutually
+    # recursive cycle whose depth is explicitly bounded by max_depth (see
+    # check_depth). That makes perl's heuristic deep-recursion warning (which
+    # fires at 100 frames) redundant noise within the allowed limit, so it is
+    # suppressed at just the recursive call sites in these three subs.
+    no warnings qw(recursion);
+    return $self->parse_inline_table($token) if $type eq 'inline_table';
+    return $self->parse_array($token);
+  }
 
   $self->parse_error($token, "value expected (bool, number, string, datetime, inline array, inline table), but found $type");
 }
@@ -353,6 +377,11 @@ sub parse_array {
   my $self  = shift;
   my $token = shift;
 
+  # Bound recursion depth before descending; the local is restored as the
+  # stack unwinds, including on error.
+  local $self->{depth} = $self->{depth} + 1;
+  $self->check_depth($token);
+
   $self->declare_key($token);
 
   my @array;
@@ -370,7 +399,10 @@ sub parse_array {
     next TOKEN if $token->{type} eq 'EOL';
     last TOKEN if $token->{type} eq 'inline_array_close';
 
-    push @array, $self->parse_value($token);
+    {
+      no warnings qw(recursion); # recursion bounded by max_depth; see parse_value
+      push @array, $self->parse_value($token);
+    }
     $expect = 'comma|EOL|inline_array_close';
   }
 
@@ -380,6 +412,11 @@ sub parse_array {
 sub parse_inline_table {
   my $self  = shift;
   my $token = shift;
+
+  # Bound recursion depth before descending; the local is restored as the
+  # stack unwinds, including on error.
+  local $self->{depth} = $self->{depth} + 1;
+  $self->check_depth($token);
 
   my $table  = {};
   my $expect = 'EOL|inline_table_close|key';
@@ -412,6 +449,7 @@ sub parse_inline_table {
       if (exists $node->{$key}) {
         $self->parse_error($token, 'duplicate key: ' .  join('.', map{ qq{"$_"} } @{ $token->{value} }));
       } else {
+        no warnings qw(recursion); # recursion bounded by max_depth; see parse_value
         $node->{ $key } = $self->parse_value($self->next_token);
       }
 

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -210,6 +210,14 @@ sub scan_to_key {
   my $keys = shift // [ $self->get_keys ];
   my $node = $self->{root};
 
+  # A dotted key descends one hash level per segment without recursing, so its
+  # length is the absolute structure depth from the root. Bound it the same way
+  # as inline array/table nesting to prevent a small document from building an
+  # arbitrarily deep structure (see check_depth).
+  if (@$keys > $self->{max_depth}) {
+    $self->parse_error(undef, "exceeded maximum nesting depth of $self->{max_depth}");
+  }
+
   KEY:
   for my $key (@$keys) {
     if (exists $node->{$key}) {
@@ -440,6 +448,13 @@ sub parse_inline_table {
       my $node = $table;
       my @keys = @{ $token->{value} };
       my $key  = pop @keys;
+
+      # A dotted key descends one hash level per intermediate segment without
+      # recursing; charge those levels against the depth budget so they (and
+      # any nested value parsed below) cannot bypass the nesting limit. The
+      # local is restored once this key/value pair is parsed.
+      local $self->{depth} = $self->{depth} + @keys;
+      $self->check_depth($token);
 
       for (@keys) {
         $node->{$_} ||= {};

--- a/t/max-depth.t
+++ b/t/max-depth.t
@@ -26,47 +26,50 @@ sub nested {
   die "unknown kind: $kind";
 }
 
-subtest 'within default depth parses' => sub {
+subtest('within default depth parses' => sub {
   for my $kind (qw(array table dotted inline_dotted)) {
     my ($data, $err) = from_toml(nested(100, $kind));
-    ok !$err, "$kind nested 100 deep parses without error"
-      or diag $err;
-    ok defined $data, "$kind returns data";
+    ok(!$err, "$kind nested 100 deep parses without error")
+      or diag($err);
+    ok(defined $data, "$kind returns data");
   }
-};
+});
 
-subtest 'exceeding default depth is rejected' => sub {
+subtest('exceeding default depth is rejected' => sub {
   for my $kind (qw(array table dotted inline_dotted)) {
     my ($data, $err) = from_toml(nested(5000, $kind));
-    ok $err, "$kind nested 5000 deep is rejected";
-    like $err, qr/depth/i, "$kind error mentions depth";
+    ok($err, "$kind nested 5000 deep is rejected");
+    like($err, qr/depth/i, "$kind error mentions depth");
   }
-};
+});
 
-subtest 'configurable max_depth' => sub {
+subtest('configurable max_depth' => sub {
   for my $kind (qw(array table dotted inline_dotted)) {
     my ($ok_data, $ok_err) = from_toml(nested(10, $kind), max_depth => 16);
-    ok !$ok_err, "$kind nested 10 deep accepted under max_depth => 16"
-      or diag $ok_err;
+    ok(!$ok_err, "$kind nested 10 deep accepted under max_depth => 16")
+      or diag($ok_err);
 
     my ($bad_data, $bad_err) = from_toml(nested(32, $kind), max_depth => 16);
-    ok $bad_err, "$kind nested 32 deep rejected under max_depth => 16";
+    ok($bad_err, "$kind nested 32 deep rejected under max_depth => 16");
   }
-};
+});
 
-subtest 'deeply nested input is rejected quickly and cheaply' => sub {
+subtest('deeply nested input is rejected quickly and cheaply' => sub {
   # Without a guard, these drive the process to multi-GB RSS and tens of
   # seconds of CPU. With the guard they must fail fast. 'dotted' and
   # 'inline_dotted' build deep structure without recursion, so they exercise
-  # the non-recursive descent paths.
+  # the non-recursive descent paths. Rejection is the assertion; the elapsed
+  # time is reported as a diagnostic only, since wall-clock budgets flake on
+  # loaded CI and a real regression would exhaust memory/stack rather than
+  # merely run slow.
   for my $kind (qw(array table dotted inline_dotted)) {
     my $src = nested(1_000_000, $kind);
     my $t0  = time;
     my ($data, $err) = from_toml($src);
     my $elapsed = time - $t0;
-    ok $err, "pathologically nested $kind input is rejected";
-    ok $elapsed < 5, "$kind rejected promptly (took ${elapsed}s)";
+    ok($err, "pathologically nested $kind input is rejected");
+    note("$kind rejected in ${elapsed}s");
   }
-};
+});
 
 done_testing;

--- a/t/max-depth.t
+++ b/t/max-depth.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny qw(from_toml);
+
+# Build a TOML document whose value for key "k" nests $depth containers deep.
+#   kind 'array': k = [[[ ... ]]]
+#   kind 'table': k = {a={a={ ... =1 }}}
+sub nested {
+  my ($depth, $kind) = @_;
+  if ($kind eq 'array') {
+    return 'k = ' . ('[' x $depth) . (']' x $depth);
+  }
+  return 'k = ' . ('{a=' x $depth) . '1' . ('}' x $depth);
+}
+
+subtest 'within default depth parses' => sub {
+  for my $kind (qw(array table)) {
+    my ($data, $err) = from_toml(nested(100, $kind));
+    ok !$err, "$kind nested 100 deep parses without error"
+      or diag $err;
+    ok defined $data, "$kind returns data";
+  }
+};
+
+subtest 'exceeding default depth is rejected' => sub {
+  for my $kind (qw(array table)) {
+    my ($data, $err) = from_toml(nested(5000, $kind));
+    ok $err, "$kind nested 5000 deep is rejected";
+    like $err, qr/depth/i, "$kind error mentions depth";
+  }
+};
+
+subtest 'configurable max_depth' => sub {
+  for my $kind (qw(array table)) {
+    my ($ok_data, $ok_err) = from_toml(nested(10, $kind), max_depth => 16);
+    ok !$ok_err, "$kind nested 10 deep accepted under max_depth => 16"
+      or diag $ok_err;
+
+    my ($bad_data, $bad_err) = from_toml(nested(32, $kind), max_depth => 16);
+    ok $bad_err, "$kind nested 32 deep rejected under max_depth => 16";
+  }
+};
+
+subtest 'deeply nested input is rejected quickly and cheaply' => sub {
+  # Without a guard, this drives the process to multi-GB RSS and tens of
+  # seconds of CPU. With the guard it must fail fast.
+  my $src = nested(1_000_000, 'array');
+  my $t0  = time;
+  my ($data, $err) = from_toml($src);
+  my $elapsed = time - $t0;
+  ok $err, 'pathologically nested input is rejected';
+  ok $elapsed < 5, "rejected promptly (took ${elapsed}s)";
+};
+
+done_testing;

--- a/t/max-depth.t
+++ b/t/max-depth.t
@@ -12,11 +12,22 @@ sub nested {
   if ($kind eq 'array') {
     return 'k = ' . ('[' x $depth) . (']' x $depth);
   }
-  return 'k = ' . ('{a=' x $depth) . '1' . ('}' x $depth);
+  if ($kind eq 'table') {
+    return 'k = ' . ('{a=' x $depth) . '1' . ('}' x $depth);
+  }
+  # Dotted keys build an equally deep structure without recursing: a key path
+  # of $depth segments nests $depth hash levels.
+  if ($kind eq 'dotted') {
+    return join('.', ('a') x $depth) . ' = 1';
+  }
+  if ($kind eq 'inline_dotted') {
+    return 'k = { ' . join('.', ('a') x $depth) . ' = 1 }';
+  }
+  die "unknown kind: $kind";
 }
 
 subtest 'within default depth parses' => sub {
-  for my $kind (qw(array table)) {
+  for my $kind (qw(array table dotted inline_dotted)) {
     my ($data, $err) = from_toml(nested(100, $kind));
     ok !$err, "$kind nested 100 deep parses without error"
       or diag $err;
@@ -25,7 +36,7 @@ subtest 'within default depth parses' => sub {
 };
 
 subtest 'exceeding default depth is rejected' => sub {
-  for my $kind (qw(array table)) {
+  for my $kind (qw(array table dotted inline_dotted)) {
     my ($data, $err) = from_toml(nested(5000, $kind));
     ok $err, "$kind nested 5000 deep is rejected";
     like $err, qr/depth/i, "$kind error mentions depth";
@@ -33,7 +44,7 @@ subtest 'exceeding default depth is rejected' => sub {
 };
 
 subtest 'configurable max_depth' => sub {
-  for my $kind (qw(array table)) {
+  for my $kind (qw(array table dotted inline_dotted)) {
     my ($ok_data, $ok_err) = from_toml(nested(10, $kind), max_depth => 16);
     ok !$ok_err, "$kind nested 10 deep accepted under max_depth => 16"
       or diag $ok_err;
@@ -44,14 +55,18 @@ subtest 'configurable max_depth' => sub {
 };
 
 subtest 'deeply nested input is rejected quickly and cheaply' => sub {
-  # Without a guard, this drives the process to multi-GB RSS and tens of
-  # seconds of CPU. With the guard it must fail fast.
-  my $src = nested(1_000_000, 'array');
-  my $t0  = time;
-  my ($data, $err) = from_toml($src);
-  my $elapsed = time - $t0;
-  ok $err, 'pathologically nested input is rejected';
-  ok $elapsed < 5, "rejected promptly (took ${elapsed}s)";
+  # Without a guard, these drive the process to multi-GB RSS and tens of
+  # seconds of CPU. With the guard they must fail fast. 'dotted' and
+  # 'inline_dotted' build deep structure without recursion, so they exercise
+  # the non-recursive descent paths.
+  for my $kind (qw(array table dotted inline_dotted)) {
+    my $src = nested(1_000_000, $kind);
+    my $t0  = time;
+    my ($data, $err) = from_toml($src);
+    my $elapsed = time - $t0;
+    ok $err, "pathologically nested $kind input is rejected";
+    ok $elapsed < 5, "$kind rejected promptly (took ${elapsed}s)";
+  }
 };
 
 done_testing;


### PR DESCRIPTION
## Summary

Bounds the depth to which the parser will build nested structures, so a
pathologically nested document can no longer drive runaway memory growth and
CPU use.

Inline arrays and inline tables were parsed via unbounded recursion, and
dotted keys built nested hashes one level per segment without recursing. Both
paths are now charged against a single configurable depth budget.

## Changes

- New `max_depth` option (default **128**, in line with other TOML parsers),
  exposed through `from_toml`/`new` and documented in the POD.
- Depth is tracked across the mutually recursive inline-value parse and the
  non-recursive dotted-key descent (inline-table and top-level paths), raising
  a normal parse error when the limit is exceeded.
- `t/max-depth.t` covers the boundary, configurability, and prompt rejection of
  pathological input across inline arrays, inline tables, and dotted keys.

## Notes

The default of 128 is far beyond what real documents require; callers needing
deeper nesting can raise it via `max_depth`. The full test suite (including the
vendored toml-test suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)