### PR TITLE
Harden parser against pathological input

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,13 @@
 - Limit maximum nesting depth of inline arrays, inline tables, and dotted
   keys (default 128, configurable via max_depth) to prevent resource
   exhaustion on pathologically nested input (Olaf Alders, Claude)
+- Keep the tokenizer's end-of-line matching linear, avoiding quadratic CPU
+  growth when parsing very long single lines (Olaf Alders, Claude)
+- Bound dotted-key depth during tokenization so a pathologically long key is
+  rejected without large transient memory use (Olaf Alders, Claude)
+- Normalize datetime fractional seconds by truncating/padding rather than
+  floating-point multiplication, fixing corrupted values for over-precise
+  fractions (Olaf Alders, Claude)
 
 0.22 2026-06-03
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@
 - Normalize datetime fractional seconds by truncating/padding rather than
   floating-point multiplication, fixing corrupted values for over-precise
   fractions (Olaf Alders, Claude)
+- Validate max_depth as a non-negative integer, failing with a clear error
+  instead of building a malformed regex on invalid input (Olaf Alders, Claude)
 
 0.22 2026-06-03
 

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -7,7 +7,7 @@ use warnings;
 no warnings qw(experimental);
 use v5.18;
 
-use Carp qw(confess);
+use Carp qw(confess croak);
 use Data::Dumper qw(Dumper);
 use Encode qw(decode FB_CROAK);
 use Math::BigFloat ();
@@ -26,6 +26,15 @@ eval{
 
 sub new {
   my ($class, %param) = @_;
+
+  # An invalid max_depth would build malformed regex quantifiers in the
+  # tokenizer; reject it here too so misuse fails loudly at construction rather
+  # than as a misleading parse error. See TOML::Tiny::Tokenizer::new.
+  if (defined $param{max_depth}) {
+    croak "max_depth must be a non-negative integer (got '$param{max_depth}')"
+      unless $param{max_depth} =~ /\A[0-9]+\z/;
+  }
+
   bless{
     inflate_integer  => $param{inflate_integer},
     inflate_float    => $param{inflate_float},

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -54,7 +54,7 @@ sub parse {
     $toml = decode('UTF-8', "$toml", FB_CROAK);
   }
 
-  $self->{tokenizer}    = TOML::Tiny::Tokenizer->new(source => $toml);
+  $self->{tokenizer}    = TOML::Tiny::Tokenizer->new(source => $toml, max_depth => $self->{max_depth});
   $self->{depth}        = 0;
   $self->{keys}         = [];
   $self->{root}         = {};

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -376,7 +376,12 @@ sub parse_datetime {
   $value =~ tr/z/Z/;
   $value =~ tr/ /T/;
   $value =~ s/t/T/;
-  $value =~ s/(\.\d+)($TimeOffset)$/sprintf(".%09d%s", $1 * 1000000000, $2)/e;
+  # Normalize fractional seconds to 9 digits (nanoseconds) by string
+  # truncate/pad -- NOT by multiplying the fraction as a float. The float form
+  # ($1 * 1_000_000_000) is lossy and overflows the field for long fractions
+  # (e.g. .999999999999999999 rounds to 1_000_000_000 -> a bogus 10-digit
+  # ".1000000000"). Truncating excess precision is permitted and faithful.
+  $value =~ s/\.(\d+)($TimeOffset)$/'.' . substr($1 . '000000000', 0, 9) . $2/e;
 
   return $self->{inflate_datetime}->($value);
 }

--- a/lib/TOML/Tiny/Tokenizer.pm
+++ b/lib/TOML/Tiny/Tokenizer.pm
@@ -7,6 +7,8 @@ no warnings qw(experimental);
 use charnames qw(:full);
 use v5.18;
 
+use Carp qw(croak);
+
 use TOML::Tiny::Grammar qw(
     $Comment
     $CRLF
@@ -27,6 +29,13 @@ sub new {
   # parser's nesting-depth guard. Defaults to the parser's default so a
   # standalone tokenizer is guarded too.
   my $max_depth = defined $param{max_depth} ? $param{max_depth} : 128;
+
+  # max_depth is interpolated into regex quantifiers ({0,N} / {N}) below. A
+  # negative or non-integer value would build a malformed regex (a literal,
+  # non-matching "{0,-5}") that silently breaks all key matching, so reject it
+  # up front as the usage error it is.
+  croak "max_depth must be a non-negative integer (got '$max_depth')"
+    unless $max_depth =~ /\A[0-9]+\z/;
 
   # A dotted key bounded to at most $max_depth + 1 segments. The key-matching
   # regexes below use this instead of the unbounded $Key: matching an unbounded

--- a/lib/TOML/Tiny/Tokenizer.pm
+++ b/lib/TOML/Tiny/Tokenizer.pm
@@ -15,7 +15,6 @@ use TOML::Tiny::Grammar qw(
     $Escape
     $Float
     $Integer
-    $Key
     $SimpleKey
     $String
     $WS
@@ -24,12 +23,41 @@ use TOML::Tiny::Grammar qw(
 sub new {
   my ($class, %param) = @_;
 
+  # Upper bound on the number of segments in a single dotted key, matching the
+  # parser's nesting-depth guard. Defaults to the parser's default so a
+  # standalone tokenizer is guarded too.
+  my $max_depth = defined $param{max_depth} ? $param{max_depth} : 128;
+
+  # A dotted key bounded to at most $max_depth + 1 segments. The key-matching
+  # regexes below use this instead of the unbounded $Key: matching an unbounded
+  # $DottedKey over a pathologically long key makes the regex engine allocate
+  # state proportional to the segment count (hundreds of MB for a ~1 MB input)
+  # before any depth check runs. Bounding the repetition caps that to
+  # O($max_depth). An over-limit key fails to match here and is reported as a
+  # depth error at the syntax-error fallthrough in next_token. The bound has no
+  # leading-optional or required-dot pitfalls (cf. the EOL fix and over_depth_key
+  # note), so it stays linear on dot-free input.
+  my $bounded_key = qr/$SimpleKey (?: $WS* \. $WS* $SimpleKey){0,$max_depth}/x;
+
   my $self = bless{
     source        => $param{source},
     last_position => length $param{source},
     position      => 0,
     line          => 1,
     last_token    => undef,
+    max_depth     => $max_depth,
+
+    key_set     => qr/\G ($bounded_key) $WS* (?= =)/x,
+    table       => qr/\G \[ $WS* ($bounded_key) $WS* \] $WS* (?:$EOL | $)/x,
+    array_table => qr/\G \[\[ $WS* ($bounded_key) $WS* \]\] $WS* (?:$EOL | $)/x,
+
+    # Detector for a dotted key (optionally a [table] / [[array]] header) deeper
+    # than the limit, used ONLY on the syntax-error path to turn what would be a
+    # generic "syntax error" into a clear depth error. It requires $max_depth
+    # dot-terminated segments, so it must NOT run per token: a required-dot regex
+    # forward-scans dot-free input to end-of-string (the same pessimization the
+    # EOL fix removed). On the error path it runs at most once.
+    over_depth_key => qr/\G \[{0,2} $WS* (?: $SimpleKey $WS* \. $WS* ){$max_depth}/x,
   }, $class;
 
   return $self;
@@ -58,9 +86,9 @@ sub next_token {
   my $type;
   my $value;
 
-  state $key_set     = qr/\G ($Key) $WS* (?= =)/x;
-  state $table       = qr/\G \[ $WS* ($Key) $WS* \] $WS* (?:$EOL | $)/x;
-  state $array_table = qr/\G \[\[ $WS* ($Key) $WS* \]\] $WS* (?:$EOL | $)/x;
+  my $key_set     = $self->{key_set};
+  my $table       = $self->{table};
+  my $array_table = $self->{array_table};
 
   state $simple = {
     '['     => 'inline_array',
@@ -156,6 +184,15 @@ sub next_token {
         last;
       }
 
+      # Nothing matched. Before reporting a generic syntax error, check whether
+      # we are stuck on a dotted key deeper than max_depth -- the bounded key
+      # regexes above refuse to match such a key, so it lands here. Report it as
+      # a depth error. This runs at most once (we are about to die either way),
+      # so the required-dot detector cannot cause per-token scanning.
+      if (/$self->{over_depth_key}/gc) {
+        $self->error(undef, "exceeded maximum nesting depth of $self->{max_depth}");
+      }
+
       my $substr = substr($self->{source}, $self->{position}, 30) // 'undef';
       die "toml syntax error on line $self->{line}\n\t-->|$substr|\n";
     }
@@ -206,14 +243,25 @@ sub error {
 }
 
 sub tokenize_key {
-  my $self = shift;
-  my $toml = shift;
-  my @segs = $toml =~ /($SimpleKey)\.?/g;
+  my $self  = shift;
+  my $toml  = shift;
+  my $limit = $self->{max_depth};
   my @keys;
 
-  for my $seg (@segs) {
+  # Split one segment at a time rather than materializing the whole list up
+  # front, so an over-long dotted key is rejected after $limit segments instead
+  # of after building all of them. A single key's segment count is its absolute
+  # depth from the root, so it is bounded exactly like nesting depth (see
+  # TOML::Tiny::Parser::scan_to_key, which still enforces the *combined*
+  # table+key depth this per-key bound cannot see).
+  while ($toml =~ /\G ($SimpleKey) (?: $WS* \. $WS* )? /gcx) {
+    my $seg = $1;
     $seg = $self->tokenize_string($seg) if $seg =~ m/^['"]/;
     push @keys, $seg;
+
+    if (defined $limit && @keys > $limit) {
+      $self->error(undef, "exceeded maximum nesting depth of $limit");
+    }
   }
 
   return \@keys;

--- a/lib/TOML/Tiny/Tokenizer.pm
+++ b/lib/TOML/Tiny/Tokenizer.pm
@@ -79,12 +79,28 @@ sub next_token {
     my $newline = !!($prev eq 'EOL' || $prev eq 'table' || $prev eq 'array_table');
 
     for ($self->{source}) {
-      /\G$WS+/gc;                # ignore whitespace
-      /\G$Comment$/mgc && next;  # ignore comments
+      /\G$WS+/gc;             # ignore whitespace
+      /\G$Comment/gc && next; # ignore comments
 
       last if /\G$/gc;
 
-      if (/\G$EOL/gc) {
+      # Match only the bare line terminator here, NOT $EOL ($Comment?$CRLF).
+      #
+      # A comment at the cursor was already consumed just above, so the optional
+      # leading comment group is dead weight -- and worse, that optional group
+      # defeats the regex engine's \G start-anchor optimization, making this
+      # per-token test forward-scan to end-of-string on every failure: O(n^2)
+      # on a long single line (a cheap CPU-exhaustion vector). $CRLF alone
+      # keeps the match anchored and linear.
+      #
+      # The comment match above uses bare $Comment (no anchoring $): $Comment's
+      # character class already stops at the line terminator (CR and LF are
+      # control chars), so it consumes exactly the comment body regardless of
+      # whether the line ends in LF or CRLF, leaving the terminator for $CRLF
+      # here. (The previous /\G$Comment$/m relied on $EOL's $Comment? to mop up
+      # CRLF-terminated comments, since $ in /m matches before LF but not before
+      # CRLF.)
+      if (/\G$CRLF/gc) {
         ++$self->{line};
         $type = 'EOL';
         last;

--- a/t/datetime-fractional-seconds.t
+++ b/t/datetime-fractional-seconds.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny qw(from_toml);
+
+#-------------------------------------------------------------------------------
+# parse_datetime normalized fractional seconds with a float multiplication
+# ($frac * 1_000_000_000), which is both lossy and can overflow the 9-digit
+# field: ".999999999999999999" rounds to 1_000_000_000 and renders as a bogus
+# 10-digit ".1000000000". Normalize by string truncate/pad to nanosecond
+# precision instead -- faithful, and never produces an out-of-range fraction.
+#
+# The default inflate_datetime returns the normalized string, so we assert on
+# the parsed value directly.
+#-------------------------------------------------------------------------------
+
+sub frac {
+  my $input = shift;
+  my ($data, $err) = from_toml("t = 1985-04-12T23:20:50${input}Z");
+  die "parse failed for '$input': $err" if $err;
+  my $v = $data->{t};
+  $v =~ /(\.\d+)Z$/ or die "no fractional seconds in '$v'";
+  return $1;
+}
+
+# Existing behavior: pad shorter fractions out to 9 digits (nanoseconds).
+is(frac('.52'),        '.520000000', 'short fraction is zero-padded to 9 digits');
+is(frac('.123456789'), '.123456789', 'exactly 9 fractional digits is preserved');
+is(frac('.000000001'), '.000000001', 'leading-zero nanoseconds preserved');
+
+# Excess precision is truncated to 9 digits, never rounded or overflowed.
+is(frac('.123456789999'),       '.123456789', 'over-precise fraction truncated to 9 digits');
+is(frac('.999999999999999999'), '.999999999', 'all-nines fraction truncates, does not overflow to 10 digits');
+is(frac('.1234567890000000000000000000001'),
+                                 '.123456789', 'absurdly long fraction handled without float error');
+
+done_testing;

--- a/t/dotted-key-memory.t
+++ b/t/dotted-key-memory.t
@@ -17,8 +17,26 @@ use Test2::V0;
 # The tokenizer must reject an over-limit dotted key BEFORE that match, keeping
 # peak RSS growth small. We measure peak RSS via /proc, so the test is
 # Linux-only; it is also resource-sensitive, so gate it on AUTHOR_TESTING (CI
-# sets it). The threshold is deliberately generous: the bug grows RSS by
-# hundreds of MB, the fix by a handful.
+# sets it).
+#
+# Each case carries its own 'max_mb' ceiling, chosen to sit between the
+# pre-fix peak and the post-fix peak so the assertion is a real regression
+# guard rather than a threshold so loose it can never fail. Measured pre-fix
+# (origin/master, unbounded $Key) vs post-fix peaks:
+#
+#   context        pre-fix   post-fix   ceiling
+#   bare key        392 MB     ~0 MB     50 MB
+#   inline table     74 MB     ~0 MB     30 MB
+#   table header      5 MB     ~0 MB     30 MB
+#
+# The bare-key and inline-table contexts both exceed their ceilings on the
+# unbounded code, so those two assertions genuinely fail without the fix. The
+# table-header context never exhibited the large amplification: its leading
+# '[' is consumed as an inline-array open before the key match would run, so
+# the unbounded $Key never matched the whole key there (pre-fix peak was only
+# ~5 MB). Its memory assertion is therefore a forward-looking ceiling, not a
+# reproduction of the bug; its primary guarantee is that the over-limit input
+# is still rejected with bounded memory.
 #-------------------------------------------------------------------------------
 
 BEGIN {
@@ -42,15 +60,14 @@ sub peak_rss_kb {
 # A 500k-segment dotted key, in each context where the tokenizer matches a key.
 # Each source is built as a single ~1 MB string (no large transient list) so the
 # only large allocation under test is whatever the parser does. 'depth_msg'
-# marks contexts that also produce a clean depth error (a grossly over-limit
-# [table] header is still rejected and still bounded, but its leading '[' is
-# consumed as an inline array before the bounded key fails, so the message is
-# generic -- memory, the security property, is what this test guards).
+# marks contexts that also produce a clean depth error (the table header gives a
+# generic error because its leading '[' is consumed as an inline array before
+# the bounded key fails -- memory, the security property, is what this guards).
 my $segs = 'a.' x 500_000;
 my @cases = (
-  { name => 'bare dotted key', depth_msg => 1, src => "$segs" . "a = 1" },
-  { name => 'inline table key', depth_msg => 1, src => "k = { ${segs}a = 1 }" },
-  { name => 'table header',     depth_msg => 0, src => "[${segs}a]\nz = 1\n" },
+  { name => 'bare dotted key', depth_msg => 1, max_mb => 50, src => "$segs" . "a = 1" },
+  { name => 'inline table key', depth_msg => 1, max_mb => 30, src => "k = { ${segs}a = 1 }" },
+  { name => 'table header',     depth_msg => 0, max_mb => 30, src => "[${segs}a]\nz = 1\n" },
 );
 
 for my $case (@cases) {
@@ -59,13 +76,13 @@ for my $case (@cases) {
   my $after  = peak_rss_kb();
   my $delta_mb = ($after - $before) / 1024;
 
-  note(sprintf '%s: peak RSS growth %.0f MB', $case->{name}, $delta_mb);
+  note(sprintf '%s: peak RSS growth %.0f MB (ceiling %d MB)', $case->{name}, $delta_mb, $case->{max_mb});
 
   ok($err, "$case->{name}: over-limit dotted key is rejected");
   like($err, qr/depth/i, "$case->{name}: rejection mentions depth")
     if $case->{depth_msg};
-  ok($delta_mb < 100,
-    sprintf('%s: peak memory stays bounded (%.0f MB < 100 MB)', $case->{name}, $delta_mb));
+  ok($delta_mb < $case->{max_mb},
+    sprintf('%s: peak memory stays bounded (%.0f MB < %d MB)', $case->{name}, $delta_mb, $case->{max_mb}));
 }
 
 done_testing;

--- a/t/dotted-key-memory.t
+++ b/t/dotted-key-memory.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+
+#-------------------------------------------------------------------------------
+# Regression guard for transient memory amplification on a huge single dotted
+# key (a.a.a.....a = 1).
+#
+# The parser bounds key-path depth, but only AFTER the tokenizer's unbounded
+# $Key match has run. Matching a $DottedKey with hundreds of thousands of
+# segments makes Perl's regex engine allocate engine state proportional to the
+# number of segments -- ~325 MB of transient RSS for a ~1 MB input -- before
+# any depth check fires. A ~400x input-to-RSS amplification is a cheap
+# memory-exhaustion vector.
+#
+# The tokenizer must reject an over-limit dotted key BEFORE that match, keeping
+# peak RSS growth small. We measure peak RSS via /proc, so the test is
+# Linux-only; it is also resource-sensitive, so gate it on AUTHOR_TESTING (CI
+# sets it). The threshold is deliberately generous: the bug grows RSS by
+# hundreds of MB, the fix by a handful.
+#-------------------------------------------------------------------------------
+
+BEGIN {
+  plan skip_all => 'resource-sensitive; set AUTHOR_TESTING=1 to run'
+    unless $ENV{AUTHOR_TESTING};
+}
+
+plan skip_all => 'requires Linux /proc/self/status for RSS measurement'
+  unless -r '/proc/self/status';
+
+use TOML::Tiny qw(from_toml);
+
+sub peak_rss_kb {
+  open my $fh, '<', '/proc/self/status' or return undef;
+  while (my $line = <$fh>) {
+    return $1 if $line =~ /^VmHWM:\s+(\d+)/;
+  }
+  return undef;
+}
+
+# A 500k-segment dotted key, in each context where the tokenizer matches a key.
+# Each source is built as a single ~1 MB string (no large transient list) so the
+# only large allocation under test is whatever the parser does. 'depth_msg'
+# marks contexts that also produce a clean depth error (a grossly over-limit
+# [table] header is still rejected and still bounded, but its leading '[' is
+# consumed as an inline array before the bounded key fails, so the message is
+# generic -- memory, the security property, is what this test guards).
+my $segs = 'a.' x 500_000;
+my @cases = (
+  { name => 'bare dotted key', depth_msg => 1, src => "$segs" . "a = 1" },
+  { name => 'inline table key', depth_msg => 1, src => "k = { ${segs}a = 1 }" },
+  { name => 'table header',     depth_msg => 0, src => "[${segs}a]\nz = 1\n" },
+);
+
+for my $case (@cases) {
+  my $before = peak_rss_kb();
+  my ($data, $err) = from_toml($case->{src});
+  my $after  = peak_rss_kb();
+  my $delta_mb = ($after - $before) / 1024;
+
+  note(sprintf '%s: peak RSS growth %.0f MB', $case->{name}, $delta_mb);
+
+  ok($err, "$case->{name}: over-limit dotted key is rejected");
+  like($err, qr/depth/i, "$case->{name}: rejection mentions depth")
+    if $case->{depth_msg};
+  ok($delta_mb < 100,
+    sprintf('%s: peak memory stays bounded (%.0f MB < 100 MB)', $case->{name}, $delta_mb));
+}
+
+done_testing;

--- a/t/max-depth-validation.t
+++ b/t/max-depth-validation.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny qw(from_toml);
+use TOML::Tiny::Parser;
+use TOML::Tiny::Tokenizer;
+
+#-------------------------------------------------------------------------------
+# max_depth is interpolated into regex quantifiers ({0,N} / {N}) built in the
+# tokenizer. A negative or non-integer value produces a MALFORMED regex: Perl
+# emits "Unescaped left brace in regex is passed through" warnings and treats
+# the quantifier as literal text, so the key regexes silently stop matching and
+# every document fails with a misleading "exceeded maximum nesting depth" error.
+#
+# An invalid max_depth is a usage error, not a parse error, so it must die
+# loudly and clearly (referencing max_depth) at construction -- not produce
+# regex warnings and bogus parse failures.
+#-------------------------------------------------------------------------------
+
+my @invalid = (
+  [ 'negative integer'      => -5    ],
+  [ 'negative one'          => -1    ],
+  [ 'fractional'            => 1.5   ],
+  [ 'non-numeric string'    => 'abc' ],
+  [ 'empty string'          => ''    ],
+);
+
+for my $case (@invalid) {
+  my ($desc, $value) = @$case;
+
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+  my $err = dies { TOML::Tiny::Parser->new(max_depth => $value) };
+  like($err, qr/max_depth/, "Parser->new rejects $desc max_depth with a clear message");
+
+  $err = dies { TOML::Tiny::Tokenizer->new(source => 'a = 1', max_depth => $value) };
+  like($err, qr/max_depth/, "Tokenizer->new rejects $desc max_depth with a clear message");
+
+  $err = dies { from_toml('a = 1', max_depth => $value) };
+  like($err, qr/max_depth/, "from_toml rejects $desc max_depth with a clear message");
+
+  is(\@warnings, [], "$desc max_depth produces no regex warnings");
+}
+
+# Valid values keep working: a non-negative integer parses normally.
+{
+  my ($data, $err) = from_toml('a.b.c.d = 1', max_depth => 16);
+  ok(!$err, 'valid max_depth parses a dotted key') or diag $err;
+  is($data, { a => { b => { c => { d => 1 } } } }, 'parsed structure is correct');
+}
+
+done_testing;

--- a/t/tokenizer-key-depth.t
+++ b/t/tokenizer-key-depth.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny qw(from_toml);
+use TOML::Tiny::Tokenizer;
+
+#-------------------------------------------------------------------------------
+# A single huge dotted key (a.a.a.....a = 1) must not materialize its full
+# per-segment list before being rejected. The parser already bounds the
+# combined key-path depth in scan_to_key, but only after the tokenizer has
+# split the entire key into an array. Bounding the split in the tokenizer --
+# tied to the same max_depth -- rejects an over-limit key without first
+# building the whole segment list.
+#-------------------------------------------------------------------------------
+
+subtest 'tokenizer bounds dotted-key segments at max_depth' => sub {
+  my $max = 16;
+  my $tok = TOML::Tiny::Tokenizer->new(source => '', max_depth => $max);
+
+  my $ok_key = join('.', ('a') x $max);
+  my $keys   = $tok->tokenize_key($ok_key);
+  is(scalar(@$keys), $max, "a key with exactly max_depth ($max) segments tokenizes");
+
+  my $big_key = join('.', ('a') x ($max + 50));
+  my $err = dies { $tok->tokenize_key($big_key) };
+  ok($err, 'over-limit dotted key is rejected during tokenization');
+  like($err, qr/depth/i, 'tokenizer error mentions depth');
+};
+
+subtest 'from_toml rejects a huge single dotted key' => sub {
+  my $src = join('.', ('a') x 100_000) . ' = 1';
+  my ($data, $err) = from_toml($src);
+  ok($err, 'pathologically long dotted key is rejected');
+  like($err, qr/depth/i, 'error mentions depth');
+};
+
+subtest 'configurable max_depth bounds dotted keys end to end' => sub {
+  my $within = join('.', ('a') x 10) . ' = 1';
+  my ($ok_data, $ok_err) = from_toml($within, max_depth => 16);
+  ok(!$ok_err, 'dotted key within max_depth is accepted') or diag($ok_err);
+
+  my $over = join('.', ('a') x 32) . ' = 1';
+  my ($bad_data, $bad_err) = from_toml($over, max_depth => 16);
+  ok($bad_err, 'dotted key over max_depth is rejected');
+};
+
+done_testing;

--- a/t/tokenizer-linear-eol.t
+++ b/t/tokenizer-linear-eol.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny::Tokenizer;
+
+#-------------------------------------------------------------------------------
+# Regression guard for a quadratic-tokenizer CPU-exhaustion vector.
+#
+# Parsing a single long line (e.g. one big flat inline array) must scale
+# roughly LINEARLY in the number of tokens. A subtle bug in the end-of-line
+# match -- an optional comment group in front of the line terminator -- caused
+# the regex engine to forward-scan to end-of-string on every token, making a
+# single long line O(n^2) and turning a ~1-2 MB document into minutes of CPU.
+#
+# Absolute wall-clock budgets flake on loaded CI (see t/max-depth.t), so we
+# assert on the machine-independent SCALING RATIO instead: quadrupling the
+# input should roughly quadruple the work (linear), not multiply it by ~16
+# (quadratic). The bug measured ~6x+ here and climbs without bound; linear is
+# ~4x, so a threshold of 5.0 sits well above linear-with-noise and well below
+# the regression.
+#
+# We measure CPU time (times()), not wall-clock: the work is CPU-bound, so the
+# quadratic shows up identically in CPU time, but CPU time is immune to
+# descheduling under the parallel (prove -j4) CI run. Still timing-sensitive,
+# so gate on AUTHOR_TESTING.
+#-------------------------------------------------------------------------------
+
+BEGIN {
+  plan skip_all => 'timing-sensitive; set AUTHOR_TESTING=1 to run'
+    unless $ENV{AUTHOR_TESTING};
+}
+
+# Drive the tokenizer directly: it is where the quadratic lived, and isolating
+# it from the parser gives a cleaner scaling signal. Returns user CPU seconds.
+sub tokenize_cpu {
+  my $n   = shift;
+  my $src = 'k = [' . join(',', (1) x $n) . ']';
+  my $tok = TOML::Tiny::Tokenizer->new(source => $src);
+  my @t0  = times;
+  my $count = 0;
+  while (my $token = $tok->next_token) { ++$count }
+  my @t1  = times;
+  # 2 tokens per element (value + comma) plus the surrounding key/=/[ ]/EOF.
+  die "tokenized $count tokens, expected ~" . (2 * $n) . "\n"
+    unless $count >= 2 * $n;
+  return $t1[0] - $t0[0];
+}
+
+my $n  = 100_000;
+my $t1 = tokenize_cpu($n);
+my $t4 = tokenize_cpu($n * 4);
+my $ratio = $t4 / ($t1 || 1e-9);
+
+note(sprintf 'tokenize %7d tokens: %.3fs CPU', $n,     $t1);
+note(sprintf 'tokenize %7d tokens: %.3fs CPU', $n * 4, $t4);
+note(sprintf 'growth for 4x input: %.2fx (linear ~4x, quadratic ~16x)', $ratio);
+
+ok($ratio < 5.0,
+  sprintf('single-line tokenization scales sub-quadratically (%.2fx < 5.0x)', $ratio));
+
+done_testing;


### PR DESCRIPTION
Hardens the tokenizer and parser against a few resource-exhaustion and correctness edge cases on pathological input, plus stricter validation of `max_depth`.

## Changes

- **Keep end-of-line matching linear.** The per-token end-of-line test had an optional leading comment group that defeated Perl's `\G` start-anchor optimization, forcing a forward-scan to end-of-string on every token. On a very long single line this made tokenizing O(n²). Restructured so comment and line-terminator are matched separately, keeping it linear. (Also fixes a CRLF-terminated comment edge case.)

- **Bound dotted-key depth during tokenization.** A single huge dotted key (`a.a.a.…=1`) made the regex engine allocate state proportional to the segment count — hundreds of MB of transient memory for a ~1 MB input — before the parser's depth guard could reject it. The key/table/array-table patterns are now bounded to `max_depth`, and `tokenize_key` streams segments and rejects past the limit, so an over-limit key is rejected with bounded memory.

- **Normalize datetime fractional seconds without float math.** Fractional seconds were normalized via float multiplication, which overflowed/garbled absurdly long fractions (e.g. `.999999999999999999` rendered as a bogus 10-digit `.1000000000`). Replaced with string truncate/pad to 9-digit nanosecond precision.

- **Validate `max_depth`.** A negative or non-integer `max_depth` was interpolated raw into regex quantifiers, producing a malformed pattern that silently broke all key matching and surfaced as a misleading depth error. It is now validated as a non-negative integer at construction (parser and tokenizer) with a clear error.

## Tests

New tests, gated on `AUTHOR_TESTING` (and Linux `/proc` for the memory test) so they don't affect normal installs while still running in CI:

- `t/tokenizer-linear-eol.t` — CPU-time scaling stays linear on long single lines.
- `t/tokenizer-key-depth.t` — dotted-key depth is bounded and configurable.
- `t/dotted-key-memory.t` — peak RSS stays bounded on a huge dotted key; per-context ceilings chosen to actually fail on the unbounded code.
- `t/datetime-fractional-seconds.t` — fractional seconds truncate/pad correctly without overflow.
- `t/max-depth-validation.t` — invalid `max_depth` fails loudly with no malformed-regex warnings.

Full recursive suite (including the BurntSushi toml-test corpus) passes: 295 files / 530 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)