### PR TITLE
Normalize datetime fractional seconds without float math

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,7 +5,8 @@
   exhaustion on pathologically nested input (Olaf Alders, Claude)
 - Normalize datetime fractional seconds by truncating/padding rather than
   floating-point multiplication, fixing corrupted values for over-precise
-  fractions (Olaf Alders, Claude)
+  fractions. Cap the captured fraction at nine digits so over-precise input
+  cannot force an oversized string allocation (Olaf Alders, Claude)
 
 0.22 2026-06-03
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@
 - Limit maximum nesting depth of inline arrays, inline tables, and dotted
   keys (default 128, configurable via max_depth) to prevent resource
   exhaustion on pathologically nested input (Olaf Alders, Claude)
+- Normalize datetime fractional seconds by truncating/padding rather than
+  floating-point multiplication, fixing corrupted values for over-precise
+  fractions (Olaf Alders, Claude)
 
 0.22 2026-06-03
 

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -376,7 +376,12 @@ sub parse_datetime {
   $value =~ tr/z/Z/;
   $value =~ tr/ /T/;
   $value =~ s/t/T/;
-  $value =~ s/(\.\d+)($TimeOffset)$/sprintf(".%09d%s", $1 * 1000000000, $2)/e;
+  # Normalize fractional seconds to 9 digits (nanoseconds) by string
+  # truncate/pad -- NOT by multiplying the fraction as a float. The float form
+  # ($1 * 1_000_000_000) is lossy and overflows the field for long fractions
+  # (e.g. .999999999999999999 rounds to 1_000_000_000 -> a bogus 10-digit
+  # ".1000000000"). Truncating excess precision is permitted and faithful.
+  $value =~ s/\.(\d+)($TimeOffset)$/'.' . substr($1 . '000000000', 0, 9) . $2/e;
 
   return $self->{inflate_datetime}->($value);
 }

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -364,8 +364,8 @@ sub parse_value {
 # TOML permits a space instead of a T, which RFC3339 does not allow. TOML (at
 # least, according to BurntSushi/toml-tests) allows z instead of Z, which
 # RFC3339 also does not permit. We will be flexible and allow them both, but
-# fix them up. TOML also specifies millisecond precision. If fractional seconds
-# are specified. Whatever.
+# fix them up. TOML does not mandate a specific sub-second precision; when
+# fractional seconds are present we normalize them to nanoseconds (9 digits).
 #-------------------------------------------------------------------------------
 sub parse_datetime {
   my $self  = shift;
@@ -381,7 +381,9 @@ sub parse_datetime {
   # ($1 * 1_000_000_000) is lossy and overflows the field for long fractions
   # (e.g. .999999999999999999 rounds to 1_000_000_000 -> a bogus 10-digit
   # ".1000000000"). Truncating excess precision is permitted and faithful.
-  $value =~ s/\.(\d+)($TimeOffset)$/'.' . substr($1 . '000000000', 0, 9) . $2/e;
+  # Capture at most 9 digits (discarding the rest) so we never allocate a
+  # string proportional to an attacker-controlled fraction length.
+  $value =~ s/\.(\d{1,9})\d*($TimeOffset)$/'.' . $1 . ('0' x (9 - length $1)) . $2/e;
 
   return $self->{inflate_datetime}->($value);
 }

--- a/t/datetime-fractional-seconds.t
+++ b/t/datetime-fractional-seconds.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use Test2::V0;
+use TOML::Tiny qw(from_toml);
+
+#-------------------------------------------------------------------------------
+# parse_datetime normalized fractional seconds with a float multiplication
+# ($frac * 1_000_000_000), which is both lossy and can overflow the 9-digit
+# field: ".999999999999999999" rounds to 1_000_000_000 and renders as a bogus
+# 10-digit ".1000000000". Normalize by string truncate/pad to nanosecond
+# precision instead -- faithful, and never produces an out-of-range fraction.
+#
+# The default inflate_datetime returns the normalized string, so we assert on
+# the parsed value directly.
+#-------------------------------------------------------------------------------
+
+sub frac {
+  my $input = shift;
+  my ($data, $err) = from_toml("t = 1985-04-12T23:20:50${input}Z");
+  die "parse failed for '$input': $err" if $err;
+  my $v = $data->{t};
+  $v =~ /(\.\d+)Z$/ or die "no fractional seconds in '$v'";
+  return $1;
+}
+
+# Existing behavior: pad shorter fractions out to 9 digits (nanoseconds).
+is(frac('.52'),        '.520000000', 'short fraction is zero-padded to 9 digits');
+is(frac('.123456789'), '.123456789', 'exactly 9 fractional digits is preserved');
+is(frac('.000000001'), '.000000001', 'leading-zero nanoseconds preserved');
+
+# Excess precision is truncated to 9 digits, never rounded or overflowed.
+is(frac('.123456789999'),       '.123456789', 'over-precise fraction truncated to 9 digits');
+is(frac('.999999999999999999'), '.999999999', 'all-nines fraction truncates, does not overflow to 10 digits');
+is(frac('.1234567890000000000000000000001'),
+                                 '.123456789', 'absurdly long fraction handled without float error');
+
+done_testing;

--- a/t/datetime-fractional-seconds.t
+++ b/t/datetime-fractional-seconds.t
@@ -15,12 +15,18 @@ use TOML::Tiny qw(from_toml);
 # the parsed value directly.
 #-------------------------------------------------------------------------------
 
+# Returns the normalized fractional-seconds portion of a parsed datetime. The
+# offset defaults to "Z"; pass a numeric offset (e.g. "+05:30") to exercise the
+# substitution's offset-reattachment ($2) branch. The match is anchored on the
+# offset, so it also asserts that the offset survives normalization intact.
 sub frac {
-  my $input = shift;
-  my ($data, $err) = from_toml("t = 1985-04-12T23:20:50${input}Z");
-  die "parse failed for '$input': $err" if $err;
+  my ($input, $offset) = @_;
+  $offset //= 'Z';
+  my ($data, $err) = from_toml("t = 1985-04-12T23:20:50${input}${offset}");
+  die "parse failed for '$input$offset': $err" if $err;
   my $v = $data->{t};
-  $v =~ /(\.\d+)Z$/ or die "no fractional seconds in '$v'";
+  my $quoted = quotemeta $offset;
+  $v =~ /(\.\d+)$quoted$/ or die "no fractional seconds with offset '$offset' in '$v'";
   return $1;
 }
 
@@ -34,5 +40,12 @@ is(frac('.123456789999'),       '.123456789', 'over-precise fraction truncated t
 is(frac('.999999999999999999'), '.999999999', 'all-nines fraction truncates, does not overflow to 10 digits');
 is(frac('.1234567890000000000000000000001'),
                                  '.123456789', 'absurdly long fraction handled without float error');
+
+# Numeric offsets exercise the $2 reattachment branch: the rewritten fraction
+# and the multi-character offset must both survive, with no digit bleed between.
+is(frac('.52', '+05:30'),        '.520000000', 'short fraction padded with a positive numeric offset');
+is(frac('.52', '-08:00'),        '.520000000', 'short fraction padded with a negative numeric offset');
+is(frac('.999999999999999999', '+05:30'),
+                                 '.999999999', 'over-precise fraction truncates cleanly with a numeric offset');
 
 done_testing;


### PR DESCRIPTION
## Summary

`TOML::Tiny::Parser::parse_datetime` normalized fractional seconds by multiplying the captured fraction as a float (`$frac * 1_000_000_000`). That is both lossy and overflows the 9-digit field for long fractions: `.999999999999999999` rounds to `1_000_000_000` and renders as a bogus 10-digit `.1000000000`.

This branch replaces the float math with a pure string truncate/pad to nanosecond (9-digit) precision — faithful to the TOML spec (which mandates no specific sub-second precision) and incapable of producing an out-of-range fraction.

## Changes

- **Float → string normalization.** Truncate/pad the fraction to 9 digits instead of multiplying as a float.
- **Bounded capture.** The substitution captures at most 9 digits (`\d{1,9}\d*`), so over-precise input can no longer force a string allocation proportional to an attacker-controlled fraction length.
- **Comment fix.** Corrected a stale block comment that claimed millisecond precision; normalization targets nanoseconds.
- **Tests.** New `t/datetime-fractional-seconds.t` covers padding, exact-9, leading-zero, truncation, all-nines (overflow regression), and absurdly long fractions. The helper also exercises numeric offsets (`+05:30`, `-08:00`) to cover the offset-reattachment branch of the substitution.

## Testing

`prove -lj4 t/` — all 26 tests pass.

## Follow-up

Fractional seconds on offset-less local datetime/time values are still not normalized (pre-existing gap, deliberately out of scope here). Tracked in #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)