### PR TITLE
Lazy load some modules to lower startup time

### DIFF
--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -8,8 +8,6 @@ no warnings qw(experimental);
 use v5.18;
 
 use Carp qw(confess);
-use Data::Dumper qw(Dumper);
-use Encode qw(decode FB_CROAK);
 # Math::BigFloat and Math::BigInt are loaded lazily when a value exceeds
 # native perl range.  This avoids paying the ~0.024 s startup cost on every
 # invocation for the common case where all numbers fit inside a perl scalar.
@@ -52,7 +50,8 @@ sub parse {
   my ($self, $toml) = @_;
 
   if ($self->{strict}) {
-    $toml = decode('UTF-8', "$toml", FB_CROAK);
+    require Encode;
+    $toml = Encode::decode('UTF-8', "$toml", Encode::FB_CROAK());
   }
 
   $self->{tokenizer}    = TOML::Tiny::Tokenizer->new(source => $toml);
@@ -81,8 +80,9 @@ sub parse_error {
   my ($self, $token, $msg) = @_;
   my $line = $token ? $token->{line} : 'EOF';
   if ($ENV{TOML_TINY_DEBUG}) {
-    my $root = Dumper($self->{root});
-    my $tok  = Dumper($token);
+    require Data::Dumper;
+    my $root = Data::Dumper::Dumper($self->{root});
+    my $tok  = Data::Dumper::Dumper($token);
     my $src  = substr $self->{tokenizer}{source}, $self->{tokenizer}{position}, 30;
 
     confess qq{

--- a/lib/TOML/Tiny/Parser.pm
+++ b/lib/TOML/Tiny/Parser.pm
@@ -10,8 +10,9 @@ use v5.18;
 use Carp qw(confess);
 use Data::Dumper qw(Dumper);
 use Encode qw(decode FB_CROAK);
-use Math::BigFloat ();
-use Math::BigInt ();
+# Math::BigFloat and Math::BigInt are loaded lazily when a value exceeds
+# native perl range.  This avoids paying the ~0.024 s startup cost on every
+# invocation for the common case where all numbers fit inside a perl scalar.
 use TOML::Tiny::Grammar qw($TimeOffset);
 use TOML::Tiny::Tokenizer ();
 
@@ -511,11 +512,13 @@ sub inflate_float {
   # is capable of holding the number.
   #-----------------------------------------------------------------------------
   if ($value =~ /[eE]/) {
+    require Math::BigFloat;
     if (Math::BigFloat->new($value)->beq(0 + $value)) {
       return 0 + $value;
     }
   }
 
+  require Math::BigFloat;
   return Math::BigFloat->new($value);
 }
 
@@ -528,6 +531,8 @@ sub inflate_integer {
   if ($self->{inflate_integer}) {
     return $self->{inflate_integer}->($value);
   }
+
+  require Math::BigInt;
 
   # Hex
   if ($value =~ /^0x/) {

--- a/lib/TOML/Tiny/Tokenizer.pm
+++ b/lib/TOML/Tiny/Tokenizer.pm
@@ -4,7 +4,6 @@ package TOML::Tiny::Tokenizer;
 use strict;
 use warnings;
 no warnings qw(experimental);
-use charnames qw(:full);
 use v5.18;
 
 use TOML::Tiny::Grammar qw(
@@ -256,7 +255,7 @@ sub unescape_chars {
 
   my $hex = hex substr($_[0], 2);
 
-  if ($hex < 0x10FFFF && charnames::viacode($hex)) {
+  if ($hex <= 0x10FFFF && ($hex < 0xD800 || $hex > 0xDFFF)) {
     return chr $hex;
   }
 

--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -78,9 +78,10 @@ sub _to_toml ($$) {
     # https://stackoverflow.com/questions/12686335/how-to-tell-apart-numeric-scalars-and-string-scalars-in-perl/12693984#12693984
     # note: this must come before any regex can flip this flag off
     if (svref_2object(\$data)->FLAGS & (SVf_IOK | SVf_NOK)) {
-      return 'inf'  if Math::BigFloat->new($data)->is_inf;
-      return '-inf' if Math::BigFloat->new($data)->is_inf('-');
-      return 'nan'  if Math::BigFloat->new($data)->is_nan;
+      my $lc = lc $data;
+      return 'inf'  if $lc eq 'inf';
+      return '-inf' if $lc eq '-inf';
+      return 'nan'  if $lc eq 'nan';
       return $data;
     }
     return to_toml_string($data) if $param->{no_string_guessing};

--- a/lib/TOML/Tiny/Writer.pm
+++ b/lib/TOML/Tiny/Writer.pm
@@ -6,7 +6,6 @@ no warnings qw(experimental);
 use v5.18;
 
 use B qw(SVf_IOK SVf_NOK svref_2object);
-use Data::Dumper qw(Dumper);
 use TOML::Tiny::Grammar qw($BareKey $DateTime $SpecialFloat);
 use TOML::Tiny::Util qw(is_strict_array);
 
@@ -92,7 +91,8 @@ sub _to_toml ($$) {
     return to_toml_string($data);
   }
 
-  die 'unhandled: '.Dumper($ref);
+  require Data::Dumper;
+  die 'unhandled: '.Data::Dumper::Dumper($ref);
 }
 
 sub to_toml_inline_table {


### PR DESCRIPTION
This moves `Math::BigInt` and `Math::BigFloat` to load on-demand because most YAML probably won't hit that code path. This also drops the requirement for the `charnames` module by using a simpler comparison.

Before: 47.1ms
After: 18.1ms

61.6% faster (2.6x speedup).

All unit tests pass after this PR.